### PR TITLE
Fix mistake in typings

### DIFF
--- a/typings/mangadex.d.ts
+++ b/typings/mangadex.d.ts
@@ -285,7 +285,7 @@ export interface Genre {
   /**
    * Genre name
    */
-  name: string
+  label: string
 }
 
 export interface SearchResult {


### PR DESCRIPTION
The TypeScript definitions listed `name` as the property to use, whenit is actually `label`. This PR fixes that