### PR TITLE
Fix "invalid URL" mistake

### DIFF
--- a/src/Agent.ts
+++ b/src/Agent.ts
@@ -404,7 +404,7 @@ export class Agent {
     body?: Record<string, unknown>
   ): Promise<T> {
     const { data: response } = await Agent.call<MangadexApiResponse<T>, 'json'>(
-      `api${!url.startsWith('/') && '/'}${url}`,
+      `${!url.startsWith('/') && '/'}${url}`,
       deepmerge(
         {
           baseUrl: 'https://mangadex.org/api/v2'


### PR DESCRIPTION
When trying to fetch manga I get an invalid URL error. Removing `API` from the suggested line fixes the issue, at least for me.