### PR TITLE
Fix Invalid Url for Followed Updates

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -149,7 +149,7 @@ export class UserResolver extends ApiBase {
     } = {}
   ): Promise<FollowedUpdates> {
     const result = await this.agent.callApi<FollowedUpdates>(
-      `user/${userId}/followed-update`,
+      `user/${userId}/followed-updates`,
       options
     )
 


### PR DESCRIPTION
When trying to fetch user followed updates it fails. Looking into it I saw a small typo in the URL.